### PR TITLE
Settings

### DIFF
--- a/src/ViperIDE.html
+++ b/src/ViperIDE.html
@@ -134,7 +134,7 @@
                         <label for="zoom">Zoom:</label>
                         <select id="zoom">
                             <option value="0.80">80%</option>
-                            <option value="1.00">100%</option>
+                            <option value="1.00" selected>100%</option>
                             <option value="1.10">110%</option>
                             <option value="1.25">125%</option>
                             <option value="1.50">150%</option>

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,121 @@
+import { QID } from './utils.js'
+
+
+const settingsElement = QID("menu-settings")
+let callbacks = new Map()
+let settings = _loadSettings()
+
+/**
+ *
+ * @param {string} setting The name of the setting to query
+ * @returns {boolean} Returns the value of the setting if found, else undefined
+ */
+export function getSetting(setting) {
+    return settings[setting]
+}
+
+
+/**
+ *
+ * @param {string} setting The name of the setting to update
+ * @param {string|boolean} newValue The new value to set the setting to (string for dropdowns, boolean for checkboxes)
+ */
+export function updateSetting(setting, newValue) {
+    // set the DOM
+    const settingElement = settingsElement.querySelector(`#${setting}`)
+    if (settingElement.tagName == "SELECT") {
+        settingElement.value = newValue
+    } else if (settingElement.type == "checkbox") {
+        settingElement.checked = newValue
+    } else {
+        console.error(`Element is not <select> or <input type="checkbox">: ${settingElement}`)
+    }
+
+    // set our local cache
+    settings[setting] = newValue
+
+    // inform any subscribers
+    _notify(setting, newValue)
+
+    // persist to local storage
+    _persistSettings(settings)
+}
+
+
+/**
+ *
+ * @param {string} setting The name of the setting to set a callback for
+ * @param {function(string):void} callback A callback function that will receive the new value of the setting
+ */
+export function onSettingChange(setting, callback) {
+    if (!callbacks.has(setting)) {
+        callbacks.set(setting, [])
+    }
+    callbacks.get(setting).push(callback)
+}
+
+
+settingsElement.addEventListener("change", (event) => {
+    settings = _persistSettings()
+    _notify(event.target.id, settings[event.target.id])
+})
+
+
+function _loadSettings() {
+    // get settings from either localstorage or read from the DOM (and populate local storage)
+    let loadedSettings = JSON.parse(localStorage.getItem("settings"))
+    if (!loadedSettings) {
+        _persistSettings()
+        loadedSettings = JSON.parse(localStorage.getItem("settings"))
+    }
+
+    function _setLoadedValue(setting, loadedValue, setter) {
+        // if we loaded nothing, then do nothing
+        if (loadedValue == undefined) {
+            return
+        }
+
+        // set the loaded value to the DOM
+        setter(loadedValue)
+
+        // notify any code that might need to know about what we loaded
+        _notify(setting, loadedValue)
+    }
+
+    // loop over all DOM settings elements and load them with the value from local storage
+    settingsElement.querySelectorAll("input[type='checkbox']").forEach(element => {
+        _setLoadedValue(element.id, loadedSettings[element.id], (value) => element.checked = value)
+    })
+    settingsElement.querySelectorAll("select").forEach(element => {
+        _setLoadedValue(element.id, loadedSettings[element.id], (value) => element.value = value)
+    })
+
+    return loadedSettings
+}
+
+
+function _persistSettings(newSettings = undefined) {
+    if (!newSettings) {
+        // nothing passed into us, so lets read from the DOM and persist that
+        newSettings = new Object()
+        settingsElement.querySelectorAll("input[type='checkbox']").forEach(element => {
+            newSettings[element.id] = element.checked
+        })
+        settingsElement.querySelectorAll("select").forEach(element => {
+            newSettings[element.id] = element.value
+        })
+    }
+
+    localStorage.setItem("settings", JSON.stringify(newSettings))
+    return newSettings
+}
+
+
+function _notify(setting, newValue) {
+    // If there are any callbacks for this setting update, then let's call them
+    if (callbacks.has(setting)) {
+        for (let callback of callbacks.get(setting)) {
+            callback(newValue)
+        }
+    }
+}

--- a/src/settings.js
+++ b/src/settings.js
@@ -69,14 +69,16 @@ function _loadSettings() {
         loadedSettings = JSON.parse(localStorage.getItem("settings"))
     }
 
-    function _setLoadedValue(setting, loadedValue, setter) {
-        // if we loaded nothing, then do nothing
-        if (loadedValue == undefined) {
-            return
+    function _setLoadedValue(setting, loadedValue, domValue, setter) {
+        // if we loaded nothing, then don't try to set the DOM (perhaps a brand new setting and
+        // therefore should use the default)
+        if (loadedValue != undefined) {
+            // set the loaded value to the DOM
+            setter(loadedValue)
+        } else {
+            loadedSettings[setting] = domValue
+            loadedValue = domValue
         }
-
-        // set the loaded value to the DOM
-        setter(loadedValue)
 
         // notify any code that might need to know about what we loaded
         _notify(setting, loadedValue)
@@ -84,10 +86,10 @@ function _loadSettings() {
 
     // loop over all DOM settings elements and load them with the value from local storage
     settingsElement.querySelectorAll("input[type='checkbox']").forEach(element => {
-        _setLoadedValue(element.id, loadedSettings[element.id], (value) => element.checked = value)
+        _setLoadedValue(element.id, loadedSettings[element.id], element.checked, (value) => element.checked = value)
     })
     settingsElement.querySelectorAll("select").forEach(element => {
-        _setLoadedValue(element.id, loadedSettings[element.id], (value) => element.value = value)
+        _setLoadedValue(element.id, loadedSettings[element.id], element.value, (value) => element.value = value)
     })
 
     return loadedSettings


### PR DESCRIPTION
This pull request introduces a new centralized settings management system and updates the codebase to use it, replacing direct DOM queries for settings. It also ensures settings are persisted in local storage and allows dynamic updates via callbacks. Additionally, it includes a minor UI improvement to the default zoom selection.

### Centralized Settings Management

* Added a new `settings.js` module with functions `getSetting`, `updateSetting`, and `onSettingChange` to manage settings centrally, persist them in local storage, and notify subscribers of changes. (`src/settings.js`)
* Replaced all instances of `QID(...).checked` and similar DOM queries with `getSetting(...)` calls for settings like `force-serial-poly`, `interrupt-device`, `advanced-mode`, and others. (`src/app.js`) [[1]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L179-R180) [[2]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L234-R235) [[3]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L441-R442) [[4]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L542-R548) [[5]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L562-R563) [[6]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L595-R596) [[7]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L734-R735)
* Updated the `applyTranslation` function to use `updateSetting` and `onSettingChange` for language and zoom level settings, enabling dynamic updates. (`src/app.js`) [[1]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L970-R973) [[2]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L1043-R1044) [[3]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6R1115-R1117)

### UI Improvements

* Updated the default zoom option in `src/ViperIDE.html` to be selected by default for better user experience. (`src/ViperIDE.html`)