### PR TITLE
Aiorepl

### DIFF
--- a/src/rawmode.js
+++ b/src/rawmode.js
@@ -8,6 +8,10 @@
 
 import { report } from "./utils"
 
+// >>> is the standard MicroPython prompt
+// --> is the aiorepl prompt
+let replPrompts = ['>>> ', '--> ']
+
 export class MpRawMode {
     constructor(port) {
         this.port = port
@@ -25,13 +29,26 @@ export class MpRawMode {
         return res
     }
 
+    async detectPrompt() {
+        await this.port.write('\r\x01')       // Ctrl-A: enter raw REPL
+        await this.port.readUntil('raw REPL; CTRL-B to exit\r\n')
+        // detect what the system prompt is and add it to our list of prompts to look for
+        const userPrompt = `${(await this.exec('print(sys.ps1)')).trim()} `
+        if (!replPrompts.includes(userPrompt)) {
+            console.log(`Detected user prompt as ${userPrompt}`)
+            replPrompts.push(userPrompt)
+        }
+        await this.port.write('\x02')     // Ctrl-B: exit raw REPL
+    }
+
     async interruptProgram(timeout=20000) {
         const endTime = Date.now() + timeout
         while (timeout <= 0 || (Date.now() < endTime)) {
             await this.port.write('\x03')   // Ctrl-C: interrupt any running program
             try {
-                let banner = await this.port.readUntil('>>> ', 500)
-                if (this.port.prevRecvCbk && banner != '\r\n>>> ') {
+                let banner = await this.port.readUntil(replPrompts, 500)
+                let promptRegex = RegExp(`\r\n(?:${replPrompts.join('|')})`)
+                if (this.port.prevRecvCbk && !promptRegex.test(banner)) {
                     this.port.prevRecvCbk(banner)
                 }
                 await this.port.flushInput()
@@ -46,6 +63,7 @@ export class MpRawMode {
     async enterRawRepl(soft_reboot=false) {
         const release = await this.port.startTransaction()
         try {
+            await this.detectPrompt()
             await this.interruptProgram()
 
             await this.port.write('\r\x01')       // Ctrl-A: enter raw REPL
@@ -60,7 +78,7 @@ export class MpRawMode {
                 try {
                     await this.port.write('\x02')     // Ctrl-B: exit raw REPL
                     await this.port.readUntil('>\r\n')
-                    await this.port.readUntil('>>> ')
+                    await this.port.readUntil(replPrompts)
                 } finally {
                     release()
                 }


### PR DESCRIPTION
This pull request enhances the MicroPython raw REPL handling by introducing dynamic prompt detection and improving the robustness of the `readUntil` method to handle multiple possible ending sequences. These changes aim to make the system more adaptable to different environments and user configurations.

### Enhancements to prompt handling in `MpRawMode`:

* Added a new method `detectPrompt` to dynamically detect and handle custom user-defined prompts in addition to standard MicroPython (`>>> `) and aiorepl (`--> `) prompts. Detected prompts are stored in the `replPrompts` array.
* Updated the `interruptProgram` and `exitRawRepl` methods to use the `replPrompts` array instead of hardcoding the `>>> ` prompt. This ensures compatibility with dynamically detected prompts. [[1]](diffhunk://#diff-5a9b57cc4a0aad15578bca21068c748f869a2f1a48ee5cd42ec5dc97014ad9b2R11-R20) [[2]](diffhunk://#diff-5a9b57cc4a0aad15578bca21068c748f869a2f1a48ee5cd42ec5dc97014ad9b2L63-R96)

### Improvements to `readUntil` in `Transport`:

* Modified the `readUntil` method to accept an array of possible ending sequences, allowing it to match any of the provided sequences. This change improves flexibility when reading data from the transport.
* Enhanced error messages in `readUntil` to specify whether the timeout occurred while waiting for a single sequence or any of multiple sequences.